### PR TITLE
Path Traversal Vulnerability in ProfileUploadBase.java

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileUploadBase.java
+++ b/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileUploadBase.java
@@ -52,7 +52,6 @@ public class ProfileUploadBase extends AssignmentEndpoint {
         return failed(this).feedback("path-traversal-profile-invalid-location").build();
       }
 
-      canonicalUploadedFile.createNewFile();
       FileCopyUtils.copy(file.getBytes(), canonicalUploadedFile);
 
       if (attemptWasMade(uploadDirectory, canonicalUploadedFile)) {


### PR DESCRIPTION
This PR fixes a Path Traversal vulnerability in the ProfileUploadBase.java file. The vulnerability allowed user-controlled input to manipulate file paths, potentially enabling unauthorized access to sensitive files.